### PR TITLE
feat: add block and transaction detail views

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -1,0 +1,9 @@
+.flex-container{
+    display: flex;
+    margin-bottom: 1rem;
+}
+
+.headings{
+    margin-left: 1rem;
+    margin-right: 2rem;
+}

--- a/src/components/Blocks/BlockDetail.jsx
+++ b/src/components/Blocks/BlockDetail.jsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import axios from 'axios'
 
+import '../../common.css'
+
 export default function BlockDetail () {
   const { height } = useParams()
-  console.log('DETIL')
   const [blockAttributes, setBlockAttributes] = useState(null)
 
   useEffect(() => {
@@ -18,8 +19,8 @@ export default function BlockDetail () {
     ? (
       <>
         <h2>Details</h2>
-        <div style={{ display: 'flex', marginBottom: '1rem' }}>
-          <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+        <div className='flex-container'>
+          <div className="headings">
             <div>Hash</div>
             <div>Time Mined</div>
             <div>Number of Transactions</div>

--- a/src/components/Blocks/BlockDetail.jsx
+++ b/src/components/Blocks/BlockDetail.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import axios from 'axios'
+
+export default function BlockDetail () {
+  const { height } = useParams()
+  console.log('DETIL')
+  const [blockAttributes, setBlockAttributes] = useState(null)
+
+  useEffect(() => {
+    axios.get(process.env.REACT_APP_BACKEND_URL + `blocks/height/${height}`).then(res => {
+      console.log(res)
+      setBlockAttributes(prevInfo => res.data)
+    }).catch(err => console.log(err))
+  }, [])
+
+  return blockAttributes
+    ? (
+      <>
+        <h2>Details</h2>
+        <div style={{ display: 'flex', marginBottom: '1rem' }}>
+          <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+            <div>Hash</div>
+            <div>Time Mined</div>
+            <div>Number of Transactions</div>
+            <div>Merkle Root</div>
+            <div>Nonce</div>
+          </div>
+
+          <div className="values">
+            <div>{blockAttributes.hash}</div>
+            <div>{blockAttributes.timestamp.split(/[TZ.]/)[0] + ' ' + blockAttributes.timestamp.split(/[TZ.]/)[1]}</div>
+            <div>{blockAttributes.num_transactions}</div>
+            <div>{blockAttributes.merkle_hash}</div>
+            <div>{blockAttributes.nonce}</div>
+          </div>
+        </div>
+
+        <h4>Block Transactions</h4>
+        {
+            blockAttributes.transactions.map((tx, idx) => {
+              return <div key={tx.hash} style = {{ marginBottom: '1rem', marginLeft: '2rem' }}><Link to={`/transactions/hash/${tx.hash}`}>{tx.hash}</Link></div>
+            })
+        }
+      </>
+
+      )
+    : <div>Loading...</div>
+}

--- a/src/components/Transactions/Input.jsx
+++ b/src/components/Transactions/Input.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { PropTypes } from 'prop-types'
+
+export default function Input ({ data }) {
+  return (
+    <div style={{ display: 'flex', marginBottom: '1rem' }}>
+      <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+        <div>Address</div>
+        <div>Value</div>
+      </div>
+
+      <div className="values">
+        <div>{data.own_addr}</div>
+        <div>{data.value} ABC</div>
+      </div>
+    </div>
+  )
+}
+
+Input.propTypes = {
+  data: PropTypes.object.isRequired
+}

--- a/src/components/Transactions/Input.jsx
+++ b/src/components/Transactions/Input.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { PropTypes } from 'prop-types'
 
+import '../../common.css'
+
 export default function Input ({ data }) {
   return (
-    <div style={{ display: 'flex', marginBottom: '1rem' }}>
-      <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+    <div className='flex-container'>
+      <div className="headings">
         <div>Address</div>
         <div>Value</div>
       </div>

--- a/src/components/Transactions/Output.jsx
+++ b/src/components/Transactions/Output.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { PropTypes } from 'prop-types'
+
+export default function Output ({ data }) {
+  return (
+    <div style={{ display: 'flex', marginBottom: '1rem' }}>
+      <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+        <div>Address</div>
+        <div>Value</div>
+      </div>
+
+      <div className="values">
+        <div>{data.own_addr}</div>
+        <div>{data.value} ABC</div>
+      </div>
+    </div>
+  )
+}
+
+Output.propTypes = {
+  data: PropTypes.object.isRequired
+}

--- a/src/components/Transactions/Output.jsx
+++ b/src/components/Transactions/Output.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { PropTypes } from 'prop-types'
 
+import '../../common.css'
+
 export default function Output ({ data }) {
   return (
-    <div style={{ display: 'flex', marginBottom: '1rem' }}>
-      <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+    <div className='flex-container'>
+      <div className="headings">
         <div>Address</div>
         <div>Value</div>
       </div>

--- a/src/components/Transactions/TransactionDetail.jsx
+++ b/src/components/Transactions/TransactionDetail.jsx
@@ -4,6 +4,7 @@ import { useParams, Link } from 'react-router-dom'
 
 import Input from './Input'
 import Output from './Output'
+import '../../common.css'
 
 export default function TransactionDetail () {
   const { txhash } = useParams()
@@ -15,12 +16,20 @@ export default function TransactionDetail () {
     }).catch(err => console.log(err))
   }, [])
 
+  function InputOutputMap (arr, Element) {
+    return (
+      arr.map((data, idx) => {
+        return <Element key = {idx} data = {data} />
+      })
+    )
+  }
+
   return transactionAttributes
     ? (
       <>
         <h2>Details</h2>
-        <div style={{ display: 'flex', marginBottom: '1rem' }}>
-          <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+        <div className='flex-container'>
+          <div className="headings">
             <div>Hash</div>
             <div>Included in Block</div>
           </div>
@@ -32,14 +41,11 @@ export default function TransactionDetail () {
         </div>
 
         <h2>Inputs</h2>
-        {transactionAttributes.inputs.map((inp, idx) => {
-          return <Input key = {idx} data = {inp}/>
-        })}
+        {InputOutputMap(transactionAttributes.inputs, Input)}
 
         <h2>Outputs</h2>
-        {transactionAttributes.outputs.map((out, idx) => {
-          return <Output key = {idx} data = {out}/>
-        })}
+        {InputOutputMap(transactionAttributes.outputs, Output)}
+
       </>
 
       )

--- a/src/components/Transactions/TransactionDetail.jsx
+++ b/src/components/Transactions/TransactionDetail.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useParams, Link } from 'react-router-dom'
+
+import Input from './Input'
+import Output from './Output'
+
+export default function TransactionDetail () {
+  const { txhash } = useParams()
+  const [transactionAttributes, setTransactionAttributes] = useState(null)
+
+  useEffect(() => {
+    axios.get(process.env.REACT_APP_BACKEND_URL + `transactions/hash/${txhash}`).then(res => {
+      setTransactionAttributes(prevInfo => res.data)
+    }).catch(err => console.log(err))
+  }, [])
+
+  return transactionAttributes
+    ? (
+      <>
+        <h2>Details</h2>
+        <div style={{ display: 'flex', marginBottom: '1rem' }}>
+          <div className="headings" style={{ marginLeft: '1rem', marginRight: '2rem' }}>
+            <div>Hash</div>
+            <div>Included in Block</div>
+          </div>
+
+          <div className="values">
+            <div>{transactionAttributes.hash}</div>
+            <div><Link to = {`/blocks/${transactionAttributes.block_num}`}>{transactionAttributes.block_num}</Link></div>
+          </div>
+        </div>
+
+        <h2>Inputs</h2>
+        {transactionAttributes.inputs.map((inp, idx) => {
+          return <Input key = {idx} data = {inp}/>
+        })}
+
+        <h2>Outputs</h2>
+        {transactionAttributes.outputs.map((out, idx) => {
+          return <Output key = {idx} data = {out}/>
+        })}
+      </>
+
+      )
+    : <div>Loading...</div>
+}


### PR DESCRIPTION
### Summary

This PR adds support for the Block and Transaction Detail Views

## Block Detail Page

The Block Detail Page look like the following:-
<img width="1511" alt="block-details" src="https://user-images.githubusercontent.com/87228907/187478004-8b993ac2-2ba7-4179-8a70-a00a8d85147c.png">

## Transaction Detail Page

The Transaction Detail Page looks like the following:-

<img width="1588" alt="transaction-details" src="https://user-images.githubusercontent.com/87228907/187478150-cf083e3d-fd75-491b-bafd-82d5696a0416.png">
